### PR TITLE
Fix mistake in documentation (#248510)

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -21,7 +21,7 @@ export type AutoQuoteOptions = {
   /**
    * Mirror for the property described in the [documentation for ReplyParameters](https://core.telegram.org/bots/api#replyparameters)
    */
-  allowSendingWithoutReply: boolean;
+  allow_sending_without_reply: boolean;
 };
 
 /**
@@ -75,7 +75,7 @@ export function addReplyParam<C extends Context>(
           message_id: (payload as any).reply_parameters?.message_id ??
             ctx.msg?.message_id,
           chat_id: (payload as any).reply_parameters?.chat_id ?? ctx.chat?.id,
-          allow_sending_without_reply: options?.allowSendingWithoutReply,
+          allow_sending_without_reply: options?.allow_sending_without_reply,
         },
       },
       signal,


### PR DESCRIPTION
either One of the two places (README.md OR mod.ts) the parameter name used is wrong.

This PR attempts to fix the spelling mistake in the mod.ts file.