### PR TITLE
fix: type incompatibility in grammy middleware

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -2,7 +2,7 @@ import type {
   Context,
   Middleware,
   Transformer,
-} from "https://deno.land/x/grammy@v1.30.0/mod.ts";
+} from "https://lib.deno.dev/x/grammy@v1/mod.ts";
 
 /**
  * Adds `reply_to_message_id` and `chat_id` to outgoing messages if not present, forcing the bot to quote the user's message whenever possible.

--- a/mod.ts
+++ b/mod.ts
@@ -2,7 +2,7 @@ import type {
   Context,
   Middleware,
   Transformer,
-} from "https://deno.land/x/grammy@v1.21.2/mod.ts";
+} from "https://deno.land/x/grammy@v1.30.0/mod.ts";
 
 /**
  * Adds `reply_to_message_id` and `chat_id` to outgoing messages if not present, forcing the bot to quote the user's message whenever possible.

--- a/scripts/transform-node.ts
+++ b/scripts/transform-node.ts
@@ -25,7 +25,7 @@ async function main(): Promise<void> {
     compilerOptions: { lib: ["ESNext"] },
     packageManager: "npm",
     mappings: {
-      "https://deno.land/x/grammy@v1.30.0/mod.ts": {
+      "https://lib.deno.dev/x/grammy@v1/mod.ts": {
         name: "grammy",
         version: "^1",
         peerDependency: true,

--- a/scripts/transform-node.ts
+++ b/scripts/transform-node.ts
@@ -25,7 +25,7 @@ async function main(): Promise<void> {
     compilerOptions: { lib: ["ESNext"] },
     packageManager: "npm",
     mappings: {
-      "https://deno.land/x/grammy@v1.21.2/mod.ts": {
+      "https://deno.land/x/grammy@v1.30.0/mod.ts": {
         name: "grammy",
         version: "^1",
         peerDependency: true,


### PR DESCRIPTION
Resolves a type incompatibility in the grammy middleware, making it compatible with the updated context types from the latest version.

Error log:
```ts
bot.use(autoQuote());
```
```ansi
Argument of type 'Middleware' is not assignable to parameter of type 'Middleware<Context>'.
  Type 'MiddlewareFn<Context>' is not assignable to type 'Middleware<Context>'.
    Type 'import("https://deno.land/x/grammy@v1.21.2/composer").MiddlewareFn<import("https://deno.land/x/grammy@v1.21.2/context").Context>' is not assignable to type 'import("https://deno.land/x/grammy@v1.30.0/composer").MiddlewareFn<import("https://deno.land/x/grammy@v1.30.0/context").Context>'.
      Types of parameters 'ctx' and 'ctx' are incompatible.
        Type 'import("https://deno.land/x/grammy@v1.30.0/context").Context' is not assignable to type 'import("https://deno.land/x/grammy@v1.21.2/context").Context'.
          The types of 'update.message' are incompatible between these types.
            Type '(import("https://deno.land/x/grammy_types@v3.14.0/message").Message & import("https://deno.land/x/grammy_types@v3.14.0/update").Update.NonChannel) | undefined' is not assignable to type '(import("https://deno.land/x/grammy_types@v3.5.2/message").Message & import("https://deno.land/x/grammy_types@v3.5.2/update").Update.NonChannel) | undefined'.
              Type 'Message & NonChannel' is not assignable to type '(Message & NonChannel) | undefined'.
                Type 'import("https://deno.land/x/grammy_types@v3.14.0/message").Message & import("https://deno.land/x/grammy_types@v3.14.0/update").Update.NonChannel' is not assignable to type 'import("https://deno.land/x/grammy_types@v3.5.2/message").Message & import("https://deno.land/x/grammy_types@v3.5.2/update").Update.NonChannel'.
                  Type 'Message & NonChannel' is not assignable to type 'Message'.
                    Types of property 'entities' are incompatible.
                      Type 'import("https://deno.land/x/grammy_types@v3.14.0/message").MessageEntity[] | undefined' is not assignable to type 'import("https://deno.land/x/grammy_types@v3.5.2/message").MessageEntity[] | undefined'.
                        Type 'import("https://deno.land/x/grammy_types@v3.14.0/message").MessageEntity[]' is not assignable to type 'import("https://deno.land/x/grammy_types@v3.5.2/message").MessageEntity[]'.
                          Type 'import("https://deno.land/x/grammy_types@v3.14.0/message").MessageEntity' is not assignable to type 'import("https://deno.land/x/grammy_types@v3.5.2/message").MessageEntity'.
                            Type 'CommonMessageEntity' is not assignable to type 'MessageEntity'.
                              Property 'user' is missing in type 'CommonMessageEntity' but required in type 'TextMentionMessageEntity'.
```