### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This plugin works by setting `reply_to_message_id` param to the value of `ctx.ms
 The plugin supports specifying the `allow_send_without_reply` parameter, which will allow the bot to send messages without quoting the user's message. To do so, just pass an object to the plugin initializer like so:
 
 ```ts
-autoQuote({ allow_send_without_reply: true });
+autoQuote({ allowSendingWithoutReply: true });
 ```
 
 ### For a single context
@@ -26,7 +26,7 @@ const bot = new Bot("");
 
 bot.command("demo", async (ctx) => {
   ctx.api.config.use(addReplyParam(ctx));
-  // ctx.api.config.use(addReplyParam(ctx, { allow_send_without_reply: true }));
+  // ctx.api.config.use(addReplyParam(ctx, { allowSendingWithoutReply: true }));
 
   ctx.reply("Demo command!"); // This will quote the user's message
 });
@@ -43,7 +43,7 @@ import { autoQuote } from "@roz/grammy-autoquote";
 const bot = new Bot("");
 
 bot.use(autoQuote());
-// bot.use(autoQuote({ allow_send_without_reply: true })
+// bot.use(autoQuote({ allowSendingWithoutReply: true }));
 
 bot.command("demo", async (ctx) => {
   ctx.reply("Demo command!"); // This will quote the user's message

--- a/mod.ts
+++ b/mod.ts
@@ -53,7 +53,7 @@ export type AutoQuoteOptions = {
  */
 export function addReplyParam<C extends Context>(
   ctx: C,
-  options?: Partial<AutoQuoteOptions>,
+  options?: AutoQuoteOptions,
 ): Transformer {
   const transformer: Transformer = (prev, method, payload, signal) => {
     if (
@@ -115,7 +115,7 @@ export function addReplyParam<C extends Context>(
  * @param options - Optional configuration options for autoQuote.
  * @returns A middleware function.
  */
-export function autoQuote(options?: Partial<AutoQuoteOptions>): Middleware {
+export function autoQuote(options?: AutoQuoteOptions): Middleware {
   return async (ctx, next) => {
     ctx.api.config.use(addReplyParam(ctx, options));
     await next();

--- a/mod.ts
+++ b/mod.ts
@@ -8,7 +8,7 @@ import type {
  * Adds `reply_to_message_id` and `chat_id` to outgoing messages if not present, forcing the bot to quote the user's message whenever possible.
  *
  * ```ts
- * import { autoQuote } from "jsr:@roz/grammy-autoquote";
+ * import { autoQuote } from "@roz/grammy-autoquote";
  * ```
  *
  * @module
@@ -32,14 +32,14 @@ export type AutoQuoteOptions = {
  * @example
  * ```ts
  * import { Bot } from "grammy";
- * import { addReplyParam } from "jsr:@roz/grammy-autoquote";
+ * import { addReplyParam } from "@roz/grammy-autoquote";
  *
  * const bot = new Bot("");
  *
  * bot.command("demo", async (ctx) => {
  *   ctx.api.config.use(addReplyParam(ctx));
  *   // OR:
- *   // ctx.api.config.use(addReplyParam(ctx, { allow_send_without_reply: true }));
+ *   // ctx.api.config.use(addReplyParam(ctx, { allowSendingWithoutReply: true }));
  *
  *   ctx.reply("Demo command!"); // This will quote the user's message
  * });
@@ -59,7 +59,7 @@ export function addReplyParam<C extends Context>(
     if (
       // If we're not calling a "send" method
       !method.startsWith("send") ||
-      // If we're calling "sendChatAction", which doesn't tak "reply_to_message_id"
+      // If we're calling "sendChatAction", which doesn't take "reply_to_message_id"
       method === "sendChatAction"
     ) {
       // Do nothing
@@ -99,7 +99,7 @@ export function addReplyParam<C extends Context>(
  *
  *  bot.use(autoQuote());
  *  // OR:
- *  // bot.use(autoQuote({ allow_send_without_reply: true })
+ *  // bot.use(autoQuote({ allowSendingWithoutReply: true })
  *
  *  bot.command("demo", async (ctx) => {
  *    ctx.reply("Demo command!"); // This will quote the user's message


### PR DESCRIPTION
Fix a few typos in the documentation and make some minor refactoring changes.